### PR TITLE
Add a default manifest file in Cosmos examples

### DIFF
--- a/cosmos/block-filtering/.gitignore
+++ b/cosmos/block-filtering/.gitignore
@@ -1,9 +1,6 @@
 /build/
 /generated/
 
-# The generated subgraph manifest
-/subgraph.yaml
-
 # Logs
 logs
 *.log

--- a/cosmos/block-filtering/subgraph.yaml
+++ b/cosmos/block-filtering/subgraph.yaml
@@ -1,0 +1,19 @@
+specVersion: 0.0.5
+description: Block Filtering Example
+repository: https://github.com/graphprotocol/example-subgraph
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: cosmos
+    name: CosmosHub
+    network: cosmoshub-4
+    source:
+      startBlock: 0
+    mapping:
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Block
+      blockHandlers:
+        - handler: handleBlock
+      file: ./src/mapping.ts

--- a/cosmos/validator-delegations/.gitignore
+++ b/cosmos/validator-delegations/.gitignore
@@ -1,9 +1,6 @@
 /build/
 /generated/
 
-# The generated subgraph manifest
-/subgraph.yaml
-
 # Logs
 logs
 *.log

--- a/cosmos/validator-delegations/subgraph.yaml
+++ b/cosmos/validator-delegations/subgraph.yaml
@@ -1,0 +1,20 @@
+specVersion: 0.0.5
+description: Validator Delegations Example
+repository: https://github.com/graphprotocol/example-subgraph
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: cosmos
+    name: CosmosHub
+    network: cosmoshub-4
+    source:
+      startBlock: 0
+    mapping:
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Delegation
+        - Coin
+      transactionHandlers:
+        - handler: handleTx
+      file: ./src/mapping.ts

--- a/cosmos/validator-rewards/.gitignore
+++ b/cosmos/validator-rewards/.gitignore
@@ -1,9 +1,6 @@
 /build/
 /generated/
 
-# The generated subgraph manifest
-/subgraph.yaml
-
 # Logs
 logs
 *.log

--- a/cosmos/validator-rewards/subgraph.yaml
+++ b/cosmos/validator-rewards/subgraph.yaml
@@ -1,0 +1,20 @@
+specVersion: 0.0.5
+description: Validator Rewards Example
+repository: https://github.com/graphprotocol/example-subgraph
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: cosmos
+    name: CosmosHub
+    network: cosmoshub-4
+    source:
+      startBlock: 0
+    mapping:
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Reward
+      eventHandlers:
+        - event: rewards
+          handler: handleReward
+      file: ./src/mapping.ts


### PR DESCRIPTION
This PR adds a manifest file in each of the generic Cosmos examples.

Even though we generate a manifest from a template, the `graph init` command expects the `subgraph.yaml` file to be present.

Related to: https://github.com/graphprotocol/graph-cli/pull/955